### PR TITLE
[PRINTER] adding comments for easier debugging

### DIFF
--- a/examples/ldisasm.rs
+++ b/examples/ldisasm.rs
@@ -17,6 +17,7 @@ fn main() {
                 AssemblyInst::with3("lea", &RAX.alloc(), &RDI.alloc(), &RSI.alloc()),
                 AssemblyInst::with0("ret"),
             ],
+            meta_insts: Vec::new(), // We can just leave this empty,
             name: "add".to_owned(),
             scope: Visibilty::Public,
         }],

--- a/examples/lir.rs
+++ b/examples/lir.rs
@@ -22,7 +22,7 @@ fn main() {
 
     module.add_func(func);
 
-    let asm = module.compile(codegen::TargetArch::X86);
+    let asm = module.compile(codegen::TargetArch::X86, false);
 
     println!("{}", asm.asm());
 }

--- a/src/codegen/asm.rs
+++ b/src/codegen/asm.rs
@@ -62,3 +62,12 @@ impl AssemblyInst {
         Some(self.ops[0].get_ty())
     }
 }
+
+/// An assembly instruction with a comment
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommentedInst {
+    /// The real instruction
+    pub insts: Vec<AssemblyInst>,
+    /// The comment
+    pub comment: String,
+}

--- a/src/codegen/comment.rs
+++ b/src/codegen/comment.rs
@@ -1,0 +1,33 @@
+use std::fmt::Display;
+
+use crate::codegen::{AllocatedIrNode, Allocation};
+
+impl Display for AllocatedIrNode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(out) = &self.alloc {
+            write!(f, "{} = ", out)?;
+        }
+
+        write!(f, "{} ", format!("{:?}", self.opcode).to_lowercase())?;
+
+        for (index, op) in self.ops.iter().enumerate() {
+            if index != 0 {
+                write!(f, ", ")?;
+            }
+
+            write!(f, "{}", op)?;
+        }
+
+        std::fmt::Result::Ok(())
+    }
+}
+
+impl Display for Allocation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Allocation::Register { id, .. } => write!(f, "reg({id})"),
+            Allocation::Stack { slot, .. } => write!(f, "stack({slot})"),
+            Allocation::Imm { num, .. } => write!(f, "{num}"),
+        }
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -2,6 +2,9 @@
 
 /// Structures for storing assembly code
 pub mod asm;
+
+/// Trait implementations for printing an allocated ir node
+mod comment;
 /// Resource dropping
 pub mod dropper;
 /// Instruction selection

--- a/src/codegen/target.rs
+++ b/src/codegen/target.rs
@@ -96,8 +96,20 @@ pub trait AsmPrinter {
             }
 
             out += &self.print_func_name(&func.name);
-            for inst in &func.insts {
-                out += &self.print_inst(inst);
+            if func.meta_insts.is_empty() {
+                for inst in &func.insts {
+                    out += &self.print_inst(inst);
+                }
+            } else {
+                for minst in &func.meta_insts {
+                    if !minst.comment.is_empty() {
+                        out += &self.print_comment(&minst.comment);
+                    }
+
+                    for inst in &minst.insts {
+                        out += &self.print_inst(inst);
+                    }
+                }
             }
         }
 

--- a/src/ir/module.rs
+++ b/src/ir/module.rs
@@ -82,7 +82,16 @@ impl Module {
     }
 
     /// Compiles the module
-    pub fn compile(&mut self, target: TargetArch) -> Compilation {
+    ///
+    /// Args:
+    ///  - `target` the target to compile to
+    ///  - `rich_comments` should comments be inserted into the assembly code
+    ///
+    /// Example:
+    /// ```rust
+    /// module.compile(codegen::TargetArch::X86, false);
+    /// ```
+    pub fn compile(&mut self, target: TargetArch, rich_comments: bool) -> Compilation {
         self.dce();
 
         let mut result = Compilation::new(target);
@@ -97,7 +106,7 @@ impl Module {
             let mut regalloc = codegen::RegAlloc::new(func.args.clone(), &*backend);
             regalloc.run(dropper.get_ir());
 
-            let mut inst = codegen::InstSelector::new(regalloc.get_ir(), &*backend);
+            let mut inst = codegen::InstSelector::new(regalloc.get_ir(), &*backend, rich_comments);
             inst.run(&mut asm);
 
             result.add(asm);


### PR DESCRIPTION
Finishes the task:

> Adding rich comments for the ir instructions (which must be optional via an argument) for easier debugging

from #1 